### PR TITLE
Fix crash in tests: Use explicit RedisCommand instead of tuple

### DIFF
--- a/Sources/RediStackTestUtils/RedisConnectionPoolIntegrationTestCase.swift
+++ b/Sources/RediStackTestUtils/RedisConnectionPoolIntegrationTestCase.swift
@@ -80,7 +80,7 @@ open class RedisConnectionPoolIntegrationTestCase: XCTestCase {
     ) throws -> RedisConnectionPool {
         let address = try SocketAddress.makeAddressResolvingHost(self.redisHostname, port: self.redisPort)
         let pool = RedisConnectionPool(
-            configuration: .init(
+            configuration: RedisConnectionPool.Configuration(
                 initialServerConnectionAddresses: [address],
                 maximumConnectionCount: .maximumActiveConnections(4),
                 connectionFactoryConfiguration: .init(connectionPassword: self.redisPassword),

--- a/Tests/RediStackIntegrationTests/RedisConnectionPoolTests.swift
+++ b/Tests/RediStackIntegrationTests/RedisConnectionPoolTests.swift
@@ -39,7 +39,8 @@ final class RedisConnectionPoolTests: RediStackConnectionPoolIntegrationTestCase
     }
     
     func test_nilConnectionRetryTimeoutStillWorks() throws {
-        let pool = try self.makeNewPool(connectionRetryTimeout: nil)
+        let pool = try self.makeNewPool(connectionRetryTimeout: .zero)
+        defer { pool.close() }
         XCTAssertNoThrow(try pool.get(#function).wait())
     }
 }

--- a/Tests/RediStackIntegrationTests/RedisConnectionPoolTests.swift
+++ b/Tests/RediStackIntegrationTests/RedisConnectionPoolTests.swift
@@ -39,7 +39,7 @@ final class RedisConnectionPoolTests: RediStackConnectionPoolIntegrationTestCase
     }
     
     func test_nilConnectionRetryTimeoutStillWorks() throws {
-        let pool = try self.makeNewPool(connectionRetryTimeout: .zero)
+        let pool = try self.makeNewPool(connectionRetryTimeout: nil)
         defer { pool.close() }
         XCTAssertNoThrow(try pool.get(#function).wait())
     }

--- a/Tests/RediStackTests/ChannelHandlers/RedisCommandHandlerTests.swift
+++ b/Tests/RediStackTests/ChannelHandlers/RedisCommandHandlerTests.swift
@@ -56,19 +56,19 @@ final class RedisCommandHandlerTests: XCTestCase {
 
         let getFoo = RESPValue.array([.bulkString(.init(string: "GET")), .bulkString(.init(string: "foo"))])
         let promiseFoo = loop.makePromise(of: RESPValue.self)
-        let commandFoo = (message: getFoo, responsePromise: promiseFoo)
+        let commandFoo = RedisCommand(message: getFoo, responsePromise: promiseFoo)
         XCTAssertNoThrow(try channel.writeOutbound(commandFoo))
         XCTAssertEqual(try channel.readOutbound(as: RESPValue.self), getFoo)
 
         let getBar = RESPValue.array([.bulkString(.init(string: "GET")), .bulkString(.init(string: "bar"))])
         let promiseBar = loop.makePromise(of: RESPValue.self)
-        let commandBar = (message: getBar, responsePromise: promiseBar)
+        let commandBar = RedisCommand(message: getBar, responsePromise: promiseBar)
         XCTAssertNoThrow(try channel.writeOutbound(commandBar))
         XCTAssertEqual(try channel.readOutbound(as: RESPValue.self), getBar)
 
         let getBaz = RESPValue.array([.bulkString(.init(string: "GET")), .bulkString(.init(string: "baz"))])
         let promiseBaz = loop.makePromise(of: RESPValue.self)
-        let commandBaz = (message: getBaz, responsePromise: promiseBaz)
+        let commandBaz = RedisCommand(message: getBaz, responsePromise: promiseBaz)
         XCTAssertNoThrow(try channel.writeOutbound(commandBaz))
         XCTAssertEqual(try channel.readOutbound(as: RESPValue.self), getBaz)
 
@@ -117,7 +117,7 @@ final class RedisCommandHandlerTests: XCTestCase {
 
         let getBar = RESPValue.array([.bulkString(.init(string: "GET")), .bulkString(.init(string: "bar"))])
         let promiseBar = loop.makePromise(of: RESPValue.self)
-        let commandBar = (message: getBar, responsePromise: promiseBar)
+        let commandBar = RedisCommand(message: getBar, responsePromise: promiseBar)
         channel.write(commandBar, promise: nil)
         XCTAssertThrowsError(try promiseBar.futureResult.wait()) {
             XCTAssertEqual($0 as? RedisClientError, .connectionClosed)


### PR DESCRIPTION
### Motivation

Currently the RediStack tests crash for our new main branch. We should have working tests.

### Changes

- Use explicit `RedisCommand` instead of tuple