### PR TITLE
Add swift-server CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+ARG swift_version=5.7
+ARG ubuntu_version=jammy
+ARG base_image=swift:$swift_version-$ubuntu_version
+FROM $base_image
+# needed to do again after FROM due to docker limitation
+ARG swift_version
+ARG ubuntu_version
+
+# set as UTF-8
+RUN apt-get update && apt-get install -y locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# dependencies
+RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools libz-dev curl jq # used by integration tests
+
+# ruby and jazzy for docs generation
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
+# jazzy no longer works on xenial as ruby is too old.
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy; fi
+
+# tools
+RUN mkdir -p $HOME/.tools
+RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
+
+# swiftformat (until part of the toolchain)
+
+ARG swiftformat_version=0.48.8
+RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
+RUN cd $HOME/.tools/swift-format && swift build -c release
+RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:20.04-5.6
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.6"
+
+  documentation-check:
+    image: redistack:20.04-5.6
+
+  test:
+    image: redistack:20.04-5.6
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: redistack:20.04-5.6

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:22.04-5.7
+    build:
+      args:
+        ubuntu_version: "jammy"
+        swift_version: "5.7"
+
+  documentation-check:
+    image: redistack:22.04-5.7
+
+  test:
+    image: redistack:22.04-5.7
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: redistack:22.04-5.7

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:22.04-5.8
+    build:
+      args:
+        ubuntu_version: "jammy"
+        swift_version: "5.8"
+
+  documentation-check:
+    image: redistack:22.04-5.8
+
+  test:
+    image: redistack:22.04-5.8
+    environment:
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: redistack:22.04-5.8

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:22.04-5.9
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.9-jammy"
+
+  documentation-check:
+    image: redistack:22.04-5.9
+
+  test:
+    image: redistack:22.04-5.9
+    environment:
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: redistack:22.04-5.9

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:22.04-main
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-jammy"
+
+  documentation-check:
+    image: redistack:22.04-main
+
+  test:
+    image: redistack:22.04-main
+    environment:
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: redistack:22.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,51 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1804.50.yaml run test
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: redistack:default
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: redistack:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code:z
+    working_dir: /code
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
+
+  soundness:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/soundness.sh"
+
+  documentation-check:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/check-docs.sh"
+    
+  test:
+    <<: *common
+    depends_on: [runtime-setup, redis]
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-}"
+    environment:
+      - REDIS_URL=redis
+
+  # util
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash
+
+  docs:
+    <<: *common
+    command: /bin/bash -cl "./scripts/generate_docs.sh"
+
+  redis:
+    image: redis:7


### PR DESCRIPTION
### Motivation

We want to use the swift-server CI going forward. For this we need to add a bunch of docker magic to work.

### Changes

- Add docker-compose files to run tests in swift-server ci

### Open ends

Some of the CI jobs will fail. We should enable it and one by one make it green. First one is already posted: #52.