### PR TITLE
Conform `RedisByteDecoder` to `NIOSingleStepByteToMessageDecoder`

### DIFF
--- a/Sources/RediStack/ChannelHandlers/RedisByteDecoder.swift
+++ b/Sources/RediStack/ChannelHandlers/RedisByteDecoder.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// and decodes them according to the Redis Serialization Protocol (RESP).
 ///
 /// See `NIO.NIOSingleStepByteToMessageDecoder`, `RESPTranslator` and [https://redis.io/topics/protocol](https://redis.io/topics/protocol)
-public struct RedisByteDecoder: NIOSingleStepByteToMessageDecoder {
+public final class RedisByteDecoder: NIOSingleStepByteToMessageDecoder {
     /// `ByteToMessageDecoder.InboundOut`
     public typealias InboundOut = RESPValue
     

--- a/Sources/RediStack/ChannelHandlers/RedisByteDecoder.swift
+++ b/Sources/RediStack/ChannelHandlers/RedisByteDecoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the RediStack open source project
 //
-// Copyright (c) 2019 RediStack project authors
+// Copyright (c) 2019-2022 RediStack project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,8 +17,8 @@ import NIOCore
 /// Handles incoming byte messages from Redis
 /// and decodes them according to the Redis Serialization Protocol (RESP).
 ///
-/// See `NIO.ByteToMessageDecoder`, `RESPTranslator` and [https://redis.io/topics/protocol](https://redis.io/topics/protocol)
-public final class RedisByteDecoder: ByteToMessageDecoder {
+/// See `NIO.NIOSingleStepByteToMessageDecoder`, `RESPTranslator` and [https://redis.io/topics/protocol](https://redis.io/topics/protocol)
+public struct RedisByteDecoder: NIOSingleStepByteToMessageDecoder {
     /// `ByteToMessageDecoder.InboundOut`
     public typealias InboundOut = RESPValue
     
@@ -28,18 +28,13 @@ public final class RedisByteDecoder: ByteToMessageDecoder {
         self.parser = RESPTranslator()
     }
 
-    /// See `ByteToMessageDecoder.decode(context:buffer:)`
-    public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-        guard let value = try self.parser.parseBytes(from: &buffer) else { return .needMoreData }
-        
-        context.fireChannelRead(wrapInboundOut(value))
-        return .continue
+    /// See `NIOSingleStepByteToMessageDecoder.decode(buffer:)`
+    public func decode(buffer: inout ByteBuffer) throws -> RESPValue? {
+        try self.parser.parseBytes(from: &buffer)
     }
 
-    /// See `ByteToMessageDecoder.decodeLast(context:buffer:seenEOF)`
-    public func decodeLast(
-        context: ChannelHandlerContext,
-        buffer: inout ByteBuffer,
-        seenEOF: Bool
-    ) throws -> DecodingState { return .needMoreData }
+    /// See `NIOSingleStepByteToMessageDecoder.decodeLast(buffer:seenEOF)`
+    public func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> RESPValue? {
+        try self.decode(buffer: &buffer)
+    }
 }


### PR DESCRIPTION
Cherry pick of:
https://gitlab.com/swift-server-community/RediStack/-/merge_requests/185

### Motivation

Traffic on the `NIOChannelPipeline` is not free, because of this recent NIO projects try to reduce the number of needed handlers for a given protocol. For example NIOSSH and NIOHTTP2 parse incoming bytes in the main ChannelHandler rather than within a dedicated DecoderHandler. To make this pattern easier the `NIOSingleStepByteToMessageDecoder` was introduced into NIO. The `NIOSingleStepByteToMessageDecoder` allows users to have an explicit decoder object within their main channel handler, that has the same semantics as the `ByteToMessageDecoder` in the channel pipeline. A usage example can be seen here:

https://github.com/vapor/postgres-nio/blob/main/Sources/PostgresNIO/New/PostgresChannelHandler.swift#L102

To allow us to move the `RedisByteDecoder` into the `RedisChannelHandler`, let's conform it to `NIOSingleStepByteToMessageDecoder`.

### Changes

Conform `RedisByteDecoder` to `NIOSingleStepByteToMessageDecoder`. This is a non breaking change since `NIOSingleStepByteToMessageDecoder` has default implementations for the `ByteToMessageDecoder` protocol, which we continue to support.