### PR TITLE
Delay connection attempts without addresses.

### DIFF
--- a/Sources/RediStack/ConnectionPool/ConnectionPool.swift
+++ b/Sources/RediStack/ConnectionPool/ConnectionPool.swift
@@ -385,7 +385,7 @@ extension ConnectionPool {
         }
         self.connectionWaiters.append(waiter)
 
-        // What are we going to wait for? Well, now we check. If the number of active connections is
+        // Ok, we have connection targets. If the number of active connections is
         // below the max, or the pool is leaky, we can create a new connection. Otherwise, we just have
         // to wait for a connection to come back.
         if self.activeConnectionCount < self.maximumConnectionCount || self.leaky {

--- a/Sources/RediStack/RedisConnectionPool.swift
+++ b/Sources/RediStack/RedisConnectionPool.swift
@@ -47,6 +47,14 @@ public class RedisConnectionPool {
     private var serverConnectionAddresses: ConnectionAddresses
     // This needs to be a var because its value changes as the pool enters/leaves pubsub mode to reuse the same connection.
     private var pubsubConnection: RedisConnection?
+    // This array buffers any request for a connection that cannot be succeeded right away in the case where we have no target.
+    // We never allow this to get larger than a specific bound, to resist DoS attacks. Past that bound we will fast-fail.
+    private var requestsForConnections: [EventLoopPromise<RedisConnection>] = []
+
+    /// The maximum number of connection requests we'll buffer in `requestsForConnections` before we start fast-failing. These
+    /// are buffered only when there are no available addresses to connect to, so in practice it's highly unlikely this will be
+    /// hit, but either way, 100 concurrent connection requests ought to be plenty in this case.
+    private static let maximumBufferedConnectionRequests = 100
 
     public init(configuration: Configuration, boundEventLoop: EventLoop) {
         var config = configuration
@@ -109,6 +117,11 @@ extension RedisConnectionPool {
 
             // This breaks the cycle between us and the pool.
             self.pool = nil
+
+            // Drop all pending connection attempts. No need to empty this manually, it'll get dropped regardless.
+            for request in self.requestsForConnections {
+                request.fail(RedisConnectionPoolError.poolClosed)
+            }
         }
     }
 
@@ -171,6 +184,14 @@ extension RedisConnectionPool {
 
         self.loop.execute {
             self.serverConnectionAddresses.update(newAddresses)
+
+            // Shiny, we can unbuffer any pending connections and pass them on as they now have somewhere to go.
+            let unbufferedRequests = self.requestsForConnections
+            self.requestsForConnections = []
+
+            for request in unbufferedRequests {
+                request.completeWith(self.connectionFactory(self.loop))
+            }
         }
     }
 
@@ -182,8 +203,17 @@ extension RedisConnectionPool {
         let factoryConfig = self.configuration.factoryConfiguration
 
         guard let nextTarget = self.serverConnectionAddresses.nextTarget() else {
-            // No valid connection target, we'll fail.
-            return targetLoop.makeFailedFuture(RedisConnectionPoolError.noAvailableConnectionTargets)
+            // No valid connection target, we'll keep track of the request and attempt to satisfy it later.
+            // First, confirm we have space to keep track of this. If not, fast-fail.
+            guard self.requestsForConnections.count < RedisConnectionPool.maximumBufferedConnectionRequests else {
+                return targetLoop.makeFailedFuture(RedisConnectionPoolError.noAvailableConnectionTargets)
+            }
+
+            // Ok, we can buffer, let's do that.
+            self.prepareLoggerForUse(nil).notice("waiting for target addresses")
+            let promise = targetLoop.makePromise(of: RedisConnection.self)
+            self.requestsForConnections.append(promise)
+            return promise.futureResult
         }
 
         let connectionConfig: RedisConnection.Configuration


### PR DESCRIPTION
Cherry pick:
https://gitlab.com/swift-server-community/RediStack/-/merge_requests/147

### Motivation

In some circumstances users may have connection pools configured without any SocketAddresses ready to go. This is particularly likely in service discovery configurations. Right now, the effect of attempting to use such a pool is two fold. First, we'll emit a bunch of error level logs telling users we have no addresses. Second, we'll fall into the exponential backoff phase of connection establishment.

The first property is annoying, but the second one is actively harmful. If your construction is timed incorrectly, we'll have the awkward problem of burning a bunch of CPU trying to create connections we know we cannot, and then a lengthy delay after the addresses are actually configured before we start trying to use them. That's the worst of all worlds.

This patch adds logic to detect the attempt to create connections when we don't have any configured addresses and delays them. This path should improve performance and ergonomics when in this mode.