### PR TITLE
Make `RedisConnection.Configuration.defaultPort` thread safe

### DIFF
--- a/Tests/RediStackTests/RedisConnection+ConfigurationTests.swift
+++ b/Tests/RediStackTests/RedisConnection+ConfigurationTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2023 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import RediStack
+import XCTest
+
+final class RedisConnection_ConfigurationTest: XCTestCase {
+
+    func testGetDefaultRedisPort() {
+        XCTAssertEqual(RedisConnection.Configuration.defaultPort, 6379)
+    }
+
+    @available(*, deprecated, message: "Testing deprecated functionality")
+    func testGetAndSetTheDefaultRedisPort() {
+        XCTAssertEqual(RedisConnection.Configuration.defaultPort, 6379)
+        RedisConnection.Configuration.defaultPort = 1234
+        XCTAssertEqual(RedisConnection.Configuration.defaultPort, 1234)
+
+        // reset the default port
+        RedisConnection.Configuration.defaultPort = 6379
+    }
+}
+


### PR DESCRIPTION
`RedisConnection.Configuration.defaultPort` is currently unprotected shared mutable state. To ensure thread safety this patch adds an atomic to back this property. Since setting the `defaultPort` doesn't make much sense for adopters, we deprecate the setter. Lastly we mark `RedisConnection.Configuration` as `Sendable`.