### PR TITLE
Add RedisClusterNodeDescription and RedisClusterNodeID

### DIFF
--- a/Sources/RediStack/Cluster/RedisClusterNodeDescriptionProtocol.swift
+++ b/Sources/RediStack/Cluster/RedisClusterNodeDescriptionProtocol.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2023 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// A description of a single node that is part of a redis cluster
+public protocol RedisClusterNodeDescriptionProtocol: Sendable, Equatable {
+    /// The node's host name.
+    var host: String? { get }
+    /// The node's ip address.
+    var ip: String? { get }
+    /// The nodes endpoint. This should normally be the ``host`` if the node has a routable hostname.
+    /// Otherwise it is the ``ip``. This property is used to create connections to the node.
+    var endpoint: String { get }
+    /// The node's redis port
+    var port: Int { get }
+    /// Defines if TLS shall be used to create a connection to the node
+    var useTLS: Bool { get }
+
+    /// A resolved SocketAddress to the node. We will remove this property as soon as we have fixed
+    /// the underlying Redis implementation.
+    var socketAddress: SocketAddress { get }
+}
+
+extension RedisClusterNodeDescriptionProtocol {
+    func isSame(_ other: some RedisClusterNodeDescriptionProtocol) -> Bool {
+        return self.ip == other.ip
+            && self.port == other.port
+            && self.endpoint == other.endpoint
+            && self.useTLS == other.useTLS
+            && self.host == other.host
+    }
+}
+
+extension RedisClusterNodeDescriptionProtocol {
+    @inlinable
+    public var id: RedisClusterNodeID {
+        RedisClusterNodeID(endpoint: self.endpoint, port: self.port)
+    }
+}

--- a/Sources/RediStack/Cluster/RedisClusterNodeDescriptionProtocol.swift
+++ b/Sources/RediStack/Cluster/RedisClusterNodeDescriptionProtocol.swift
@@ -34,7 +34,7 @@ public protocol RedisClusterNodeDescriptionProtocol: Sendable, Equatable {
 }
 
 extension RedisClusterNodeDescriptionProtocol {
-    func isSame(_ other: some RedisClusterNodeDescriptionProtocol) -> Bool {
+    func isSame<Other: RedisClusterNodeDescriptionProtocol>(_ other: Other) -> Bool {
         return self.ip == other.ip
             && self.port == other.port
             && self.endpoint == other.endpoint

--- a/Sources/RediStack/Cluster/RedisClusterNodeID.swift
+++ b/Sources/RediStack/Cluster/RedisClusterNodeID.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2023 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Properties to identifiy a Node in a Redis cluster
+public struct RedisClusterNodeID: Hashable, Sendable {
+    /// The node's endpoint. This might be the hostname (preferred) or ip address
+    public var endpoint: String
+    /// The node's redis port
+    public var port: Int
+
+    public init(endpoint: String, port: Int) {
+        self.endpoint = endpoint
+        self.port = port
+    }
+}

--- a/Tests/RediStackTests/Cluster/RedisClusterNodeDescriptionProtocolTests.swift
+++ b/Tests/RediStackTests/Cluster/RedisClusterNodeDescriptionProtocolTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2023 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import RediStack
+
+final class RedisClusterNodeDescriptionProtocolTests: XCTestCase {
+    func testIsSame() {
+        let node1 = MockNodeDescription(host: "redis1", ip: "127.0.0.1", useTLS: true)
+        let node2 = MockNodeDescription(host: "redis2", ip: "127.0.0.2", useTLS: true)
+
+        XCTAssertTrue(node1.isSame(node1))
+        XCTAssertTrue(node2.isSame(node2))
+        XCTAssertFalse(node2.isSame(node1))
+    }
+
+    func testNodeID() {
+        let node1 = MockNodeDescription(host: "redis1", ip: "127.0.0.1", useTLS: true)
+        let node2 = MockNodeDescription(host: "redis2", ip: "127.0.0.2", useTLS: true)
+
+        XCTAssertEqual(node1.id, .init(endpoint: "redis1", port: 6379))
+        XCTAssertEqual(node2.id, .init(endpoint: "redis2", port: 6379))
+    }
+}

--- a/Tests/RediStackTests/Helpers/MockNodeDescription.swift
+++ b/Tests/RediStackTests/Helpers/MockNodeDescription.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2023 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import RediStack
+import NIOCore
+
+struct MockNodeDescription: RedisClusterNodeDescriptionProtocol, Hashable {
+    var host: String?
+    var endpoint: String
+    var ip: String?
+    var port: Int = 5432
+    var useTLS: Bool
+
+    var socketAddress: SocketAddress { try! .makeAddressResolvingHost(self.endpoint, port: self.port) }
+
+    init(host: String? = "localhost", ip: String, endpoint: String? = nil, port: Int = 6379, useTLS: Bool) {
+        self.host = host
+        self.ip = ip
+        self.endpoint = endpoint ?? host ?? ip
+        self.port = port
+        self.useTLS = useTLS
+    }
+}


### PR DESCRIPTION
To build out a generic Redis Cluster implementation, we need a way to identify cluster nodes. This patch adds `RedisClusterNodeDescriptionProtocol` and `RedisClusterNodeID` to solve this. Follow up PRs will introduce `RedisClusterShardDescriptionProtocol` that build ontop of this functionality.