### PR TITLE
fix AsyncStream polyfill swift<5.9

### DIFF
--- a/Sources/RediStack/Cluster/SwiftPolyfill.swift
+++ b/Sources/RediStack/Cluster/SwiftPolyfill.swift
@@ -36,6 +36,7 @@ extension DiscardingTaskGroup: DiscardingTaskGroupProtocol {}
 
 #if swift(<5.9)
 // This should be removed once we support Swift 5.9+ only
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncStream {
     static func makeStream(
         of elementType: Element.Type = Element.self,


### PR DESCRIPTION
closes https://github.com/swift-server/RediStack/issues/100

verified on swift version `5.8.1`