### PR TITLE
Make connection retry timeout default consistent

### DIFF
--- a/Sources/RediStack/ConnectionPool/RedisConnectionPool+Configuration.swift
+++ b/Sources/RediStack/ConnectionPool/RedisConnectionPool+Configuration.swift
@@ -83,6 +83,8 @@ extension RedisConnectionPool {
     /// A configuration object for connection pools.
     /// - Warning: This type has **reference** semantics due to `ConnectionFactoryConfiguration`.
     public struct Configuration {
+        /// The default connection retry timeout
+        public static let defaultConnectionRetryTimeout: TimeAmount = .seconds(60)
         /// The set of Redis servers to which this pool is initially willing to connect.
         public let initialConnectionAddresses: [SocketAddress]
         /// The minimum number of connections to preserve in the pool.
@@ -124,7 +126,7 @@ extension RedisConnectionPool {
             minimumConnectionCount: Int = 1,
             connectionBackoffFactor: Float32 = 2,
             initialConnectionBackoffDelay: TimeAmount = .milliseconds(100),
-            connectionRetryTimeout: TimeAmount? = .seconds(60),
+            connectionRetryTimeout: TimeAmount? = defaultConnectionRetryTimeout,
             onUnexpectedConnectionClose: ((RedisConnection) -> Void)? = nil,
             poolDefaultLogger: Logger? = nil
         ) {
@@ -134,7 +136,7 @@ extension RedisConnectionPool {
             self.minimumConnectionCount = minimumConnectionCount
             self.connectionRetryConfiguration = (
                 (initialConnectionBackoffDelay, connectionBackoffFactor),
-                connectionRetryTimeout ?? .milliseconds(10) // always default to a baseline 10ms
+                connectionRetryTimeout ?? defaultConnectionRetryTimeout
             )
             self.onUnexpectedConnectionClose = onUnexpectedConnectionClose
             self.poolDefaultLogger = poolDefaultLogger ?? .redisBaseConnectionPoolLogger


### PR DESCRIPTION
Fix for #104. Makes the connection retry timeout consistent regardless of whether no value is specified, or `nil` is specified.

Test failures seem to be due to the specific test comparing floats:

Test Suite 'StringCommandsTests' failed at 2024-03-20 15:05:53.225.
	 Executed 17 tests, with 2 failures (0 unexpected) in 0.576 (0.577) seconds
Test Suite 'RediStackPackageTests.xctest' failed at 2024-03-20 15:05:53.225.
	 Executed 264 tests, with 2 failures (0 unexpected) in 38.703 (38.716) seconds
Test Suite 'All tests' failed at 2024-03-20 15:05:53.225.
	 Executed 264 tests, with 2 failures (0 unexpected) in 38.703 (38.717) seconds

```
…/RediStack/Tests/RediStackIntegrationTests/Commands/StringCommandsTests.swift:212: error: -[RediStackIntegrationTests.StringCommandsTests test_incrementByFloat] : XCTAssertEqual failed: ("3.1479989999999987") is not equal to ("3.147999")
…/RediStack/Tests/RediStackIntegrationTests/Commands/StringCommandsTests.swift:214: error: -[RediStackIntegrationTests.StringCommandsTests test_incrementByFloat] : XCTAssertEqual failed: ("18.441798999999996") is not equal to ("18.441799")
```
