### PR TITLE
Pipelining support 

### DIFF
--- a/Sources/RediStack/RedisConnection.swift
+++ b/Sources/RediStack/RedisConnection.swift
@@ -246,10 +246,6 @@ extension RedisConnection {
     /// - Note: The timing of when commands are actually sent to Redis can be controlled with the `RedisConnection.sendCommandsImmediately` property.
     /// - Returns: A `NIO.EventLoopFuture` that resolves with the command's result stored in a `RESPValue`.
     ///     If a `RedisError` is returned, the future will be failed instead.
-    public func sendPipeline(commands: [(command: String, arguments: [RESPValue])]) -> EventLoopFuture<RESPValue> {
-        return self.send(commands: commands, logger: nil)
-    }
-
     public func send<T>(_ command: T) -> EventLoopFuture<T.Value> where T : RedisCommandSignature {
         return self.send(commands: command.commands, logger: nil)
             .flatMapThrowing(command.makeResponse)

--- a/Sources/RediStack/RedisConnection.swift
+++ b/Sources/RediStack/RedisConnection.swift
@@ -250,6 +250,11 @@ extension RedisConnection {
         return self.send(commands: commands, logger: nil)
     }
 
+    public func send<T>(_ command: T) -> EventLoopFuture<T.Value> where T : RedisCommandSignature {
+        return self.send(commands: command.commands, logger: nil)
+            .flatMapThrowing(command.makeResponse)
+    }
+
     internal func send(
         command: String,
         with arguments: [RESPValue],

--- a/Sources/RediStack/RedisPipelineClient.swift
+++ b/Sources/RediStack/RedisPipelineClient.swift
@@ -24,6 +24,11 @@ import NIOCore
 ///
 /// For the full list of available commands, see [https://redis.io/commands](https://redis.io/commands)
 public protocol RedisPipelineClient: RedisClient {
+    func send<T: RedisCommandSignature>(_ command: T) -> EventLoopFuture<T.Value>
+}
 
-    func sendPipeline(commands: [(command: String, arguments: [RESPValue])]) -> EventLoopFuture<RESPValue>
+public protocol RedisCommandSignature<Value> {
+    associatedtype Value
+    var commands: [(command: String, arguments: [RESPValue])] { get }
+    func makeResponse(from response: RESPValue) throws -> Value
 }

--- a/Sources/RediStack/RedisPipelineClient.swift
+++ b/Sources/RediStack/RedisPipelineClient.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the RediStack open source project
+//
+// Copyright (c) 2019-2020 RediStack project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of RediStack project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import protocol Foundation.LocalizedError
+import struct Logging.Logger
+import NIOCore
+
+/// An object capable of sending commands pipelines and receiving responses.
+///
+///     let client = ...
+///     let result = client.send(commands: [("GET", ["my_key"])])
+///     // result == EventLoopFuture<RESPValue>
+///
+/// For the full list of available commands, see [https://redis.io/commands](https://redis.io/commands)
+public protocol RedisPipelineClient: RedisClient {
+
+    func sendPipeline(commands: [(command: String, arguments: [RESPValue])]) -> EventLoopFuture<RESPValue>
+}


### PR DESCRIPTION
[Pipelining](https://redis.io/docs/latest/develop/use/pipelining/) is an important feature, and I have implemented basic support for it in this PR with the `RedisPipelineClient` protocol. I have added a new protocol instead of changing `RedisClient` to maintain backward compatibility.

```swift
public protocol RedisPipelineClient: RedisClient {
    func send<T: RedisCommandSignature>(_ command: T) -> EventLoopFuture<T.Value>
}

public protocol RedisCommandSignature<Value> {
    associatedtype Value
    var commands: [(command: String, arguments: [RESPValue])] { get }
    func makeResponse(from response: RESPValue) throws -> Value
}
```

I would like to support pipelining more natively, perhaps with a builder like:
```swift
client.pipeline { builder in
    builder
        .delete(someKey)
        .ttl(.expireDate)
}
```

However, this would require significant changes to the library. Therefore, I have decided to first propose this core support.