### PR TITLE
zpop commands have score as second parameter not first

### DIFF
--- a/Sources/RediStack/Commands/SortedSetCommands.swift
+++ b/Sources/RediStack/Commands/SortedSetCommands.swift
@@ -611,7 +611,7 @@ extension RedisClient {
 
         return send(command: command, with: args)
             .tryConverting(to: [RESPValue].self)
-            .flatMapThrowing { try Self._mapSortedSetResponse($0, scoreIsFirst: true) }
+            .flatMapThrowing { try Self._mapSortedSetResponse($0, scoreIsFirst: false) }
     }
 }
 


### PR DESCRIPTION
Fix zpop commands. They have been set to read the first value as the score when it is the second value.

See https://redis.io/docs/latest/commands/zpopmin/ for reference                        
